### PR TITLE
Add shebang line allowing it to be run as binary and mark it as executable

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/bin/env python
+
 import curses
 from curses import wrapper
 import time


### PR DESCRIPTION
Makes it more convenient, now it can be placed in /usr/bin for example and run as a regular program.